### PR TITLE
started work on residue wise calculations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,4 +3,5 @@ BasedOnStyle: WebKit
 TabWidth: '4'
 UseTab: Always
 NamespaceIndentation: All
+ColumnLimit: 80
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.9)
 project(ProStruct)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 option(ENABLE_TESTING "Enable tests" OFF)
 option(OPTIMIZE_FOR_NATIVE "Build with -march=native" ON)

--- a/devtools/travis-ci/install_libraries.sh
+++ b/devtools/travis-ci/install_libraries.sh
@@ -4,9 +4,9 @@ cd $HOME
 
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -y
-sudo apt-get install gcc-5 g++-5 autotools-dev libicu-dev build-essential libbz2-dev libblas-dev liblapack-dev -y
+sudo apt-get install gcc-6 g++-6 autotools-dev libicu-dev build-essential libbz2-dev libblas-dev liblapack-dev -y
 # increase priority of gcc5 and g++5
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 150 --slave /usr/bin/g++ g++ /usr/bin/g++-5
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 150 --slave /usr/bin/g++ g++ /usr/bin/g++-6
 
 # install armadillo 7.8 manually (trusty only has older versions)
 git clone -b 7.800.x https://gitlab.com/conradsnicta/armadillo-code.git

--- a/devtools/travis-ci/install_libraries.sh
+++ b/devtools/travis-ci/install_libraries.sh
@@ -5,7 +5,7 @@ cd $HOME
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -y
 sudo apt-get install gcc-6 g++-6 autotools-dev libicu-dev build-essential libbz2-dev libblas-dev liblapack-dev -y
-# increase priority of gcc5 and g++5
+# increase priority of gcc6 and g++6
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 150 --slave /usr/bin/g++ g++ /usr/bin/g++-6
 
 # install armadillo 7.8 manually (trusty only has older versions)

--- a/src/prostruct/parsers/PDBparser.cpp
+++ b/src/prostruct/parsers/PDBparser.cpp
@@ -75,9 +75,7 @@ void createMap(
 			}
 
 			auto residueID = residue + "-" + resSeqStr + "-" + insCode;
-			auto atom = std::make_shared<Atom<T>>(element, name, x, y, z);
-
-			chainResMap[chainID][residueID].emplace_back(atom);
+			chainResMap[chainID][residueID].emplace_back(std::make_shared<Atom<T>>(element, name, x, y, z));
 		}
 	}
 }

--- a/src/prostruct/pdb/PDB.cpp
+++ b/src/prostruct/pdb/PDB.cpp
@@ -220,10 +220,10 @@ arma::Col<T> PDB<T>::calculate_phi_psi()
 }
 
 template <typename T>
-arma::Col<T> PDB<T>::calculate_phi()
+arma::Col<T> PDB<T>::calculate_phi(bool use_radians)
 {
 	// convert from radians to degrees
-	constexpr T coef = (180.0 / M_PI);
+	T coef = use_radians ? 1.0 : to_rad_constant;
 	// the Phi kernel as a C++ lambda
 	auto lambda = [coef](const auto& residue,
 					 const auto& residue_next
@@ -243,7 +243,7 @@ arma::Col<T> PDB<T>::calculate_phi()
 	};
 
 	// result is a matrix where each row has the lambda/kernel result for each residue, so transform it into column vector
-	return arma::Col<T>(geometry::atom_calculation_engine<2>(m_residues, lambda).memptr(), m_residues.size());
+	return arma::Col<T>(geometry::atom_calculation_engine<2>(m_residues, 0, lambda).memptr(), m_residues.size());
 }
 
 template <typename T>

--- a/src/prostruct/pdb/PDB.h
+++ b/src/prostruct/pdb/PDB.h
@@ -67,11 +67,14 @@ public:
 
 	void recentre();
 
-	arma::Mat<T> calculate_phi_psi();
+	arma::Col<T> calculate_phi_psi();
 
 	void kabsch_rotation(PDB<T>& other);
 
 	T kabsch_rmsd(PDB<T>& other);
+
+	arma::Col<T> calculate_phi();
+	arma::Col<T> calculate_psi();
 
 	//    void rotate(arma::Col<T> &rotation); // rotation = [rotation_x,
 	//    rotation_y, rotation_z] void rotate(T rotation_angle, std::string axis);
@@ -106,6 +109,7 @@ private:
 	std::vector<std::string> m_chain_order;
 	arma::uword m_nresidues;
 	arma::Col<T> m_radii;
+	residueVector<T> m_residues;
 
 	void internalKS(arma::Mat<T>&);
 	arma::Mat<T> get_backbone_atoms();

--- a/src/prostruct/pdb/PDB.h
+++ b/src/prostruct/pdb/PDB.h
@@ -73,7 +73,7 @@ public:
 
 	T kabsch_rmsd(PDB<T>& other);
 
-	arma::Col<T> calculate_phi();
+	arma::Col<T> calculate_phi(bool use_radians = false);
 	arma::Col<T> calculate_psi();
 
 	//    void rotate(arma::Col<T> &rotation); // rotation = [rotation_x,
@@ -110,6 +110,7 @@ private:
 	arma::uword m_nresidues;
 	arma::Col<T> m_radii;
 	residueVector<T> m_residues;
+	static constexpr T to_rad_constant = 180.0 / M_PI;
 
 	void internalKS(arma::Mat<T>&);
 	arma::Mat<T> get_backbone_atoms();

--- a/src/prostruct/pdb/PDB.h
+++ b/src/prostruct/pdb/PDB.h
@@ -17,104 +17,113 @@
 #include <fmt/format.h>
 
 namespace prostruct {
-    std::set<std::string> backbone_atom_names = {"C", "CA", "N", "O"};
-template <typename T>
-class PDB {
-public:
-	PDB(const std::string& filename);
+	std::set<std::string> backbone_atom_names = { "C", "CA", "N", "O" };
+	template <typename T> class PDB {
+	public:
+		PDB(const std::string& filename);
 
-	~PDB() = default;
+		static PDB fetch(std::string);
 
-	static PDB fetch(std::string);
-
-	std::string to_string()
-	{
-		return format(
-			fmt("<prostruct.PDB {} precision, with {} atoms, {} residues at {}>"),
-			demangled_type<T>(), m_natoms, m_nresidues, fmt::ptr(this));
-	}
-
-	std::string get_filename() { return m_filename; }
-
-	int n_chains() { return m_number_of_chains; }
-
-	std::vector<std::string> get_chain_names() { return m_chain_order; }
-
-	std::shared_ptr<Chain<T>> get_chain(std::string name_)
-	{
-		return m_chain_map[name_];
-	}
-
-	arma::Mat<T> compute_kabsch_sander();
-
-	arma::Mat<T> predict_backbone_hbonds();
-
-	void compute_dssp();
-
-	arma::Mat<T> get_xyz() { return m_xyz; }
-
-	int n_residues() { return m_nresidues; }
-
-	int n_atoms() { return m_natoms; }
-
-	arma::Col<T> get_radii() { return m_radii; }
-
-	arma::Col<T> compute_shrake_rupley(T probe=1.4, int n_sphere_points=960);
-
-	T calculate_RMSD(PDB& other);
-
-	arma::Col<T> calculate_centroid();
-
-	void recentre();
-
-	arma::Col<T> calculate_phi_psi();
-
-	void kabsch_rotation(PDB<T>& other);
-
-	T kabsch_rmsd(PDB<T>& other);
-
-	arma::Col<T> calculate_phi(bool use_radians = false);
-	arma::Col<T> calculate_psi();
-
-	//    void rotate(arma::Col<T> &rotation); // rotation = [rotation_x,
-	//    rotation_y, rotation_z] void rotate(T rotation_angle, std::string axis);
-	//    // axis = {"x", "y", "z"}
-#ifndef SWIG
-	template <typename...Args>
-	arma::Col<arma::uword> get_atom_indices(Args... patterns) 
-	{
-		arma::Col<arma::uword> max_result(m_nresidues*m_natoms);
-		arma::uword i = 0;
-	    arma::uword position_in_pdb = 0;
-	    
-		for(const auto& chain_name: m_chain_order) {
-			arma::Col<arma::uword> residue_atoms = m_chain_map[chain_name]->get_atom_indices(std::forward<Args>(patterns)...);
-			max_result(arma::span(i, i+residue_atoms.n_rows-1)) = residue_atoms + position_in_pdb;
-			i+=residue_atoms.n_rows;
-			position_in_pdb += m_chain_map[chain_name]->m_natoms;
+		std::string to_string()
+		{
+			return format(fmt("<prostruct.PDB {} precision, with {} atoms, {} "
+							  "residues at {}>"),
+				demangled_type<T>(), m_natoms, m_nresidues, fmt::ptr(this));
 		}
 
-		arma::Col<arma::uword> result = max_result.head(i);
+		std::string get_filename() { return m_filename; }
 
-		return result;
-	}
+		int n_chains() { return m_number_of_chains; }
+
+		std::vector<std::string> get_chain_names() const noexcept
+		{
+			return m_chain_order;
+		}
+
+		std::shared_ptr<Chain<T>> get_chain(const std::string& name) const
+		{
+			return m_chain_map.at(name);
+		}
+
+		arma::Mat<T> compute_kabsch_sander() const;
+
+		arma::Mat<T> predict_backbone_hbonds() const;
+
+		void compute_dssp() const;
+
+		arma::Mat<T> get_xyz() const noexcept { return m_xyz; }
+
+		int n_residues() const noexcept { return m_nresidues; }
+
+		int n_atoms() const noexcept { return m_natoms; }
+
+		arma::Col<T> get_radii() const noexcept { return m_radii; }
+
+		arma::Col<T> compute_shrake_rupley(
+			T probe = 1.4, int n_sphere_points = 960) const;
+
+		T calculate_RMSD(PDB& other) const;
+
+		arma::Col<T> calculate_centroid() const;
+
+		void recentre();
+
+		arma::Mat<T> calculate_phi_psi(bool use_radians = false) const;
+
+		void kabsch_rotation(PDB<T>& other);
+
+		T kabsch_rmsd(PDB<T>& other) const;
+
+		arma::Col<T> calculate_phi(bool use_radians = false) const;
+		arma::Col<T> calculate_psi(bool use_radians = false) const;
+
+		//    void rotate(arma::Col<T> &rotation); // rotation = [rotation_x,
+		//    rotation_y, rotation_z] void rotate(T rotation_angle, std::string
+		//    axis);
+		//    // axis = {"x", "y", "z"}
+#ifndef SWIG
+		template <typename... Args>
+		arma::Col<arma::uword> get_atom_indices(Args... patterns)
+		{
+			arma::Col<arma::uword> max_result(m_nresidues * m_natoms);
+			arma::uword i = 0;
+			arma::uword position_in_pdb = 0;
+
+			for (const auto& chain_name : m_chain_order) {
+				arma::Col<arma::uword> residue_atoms
+					= m_chain_map[chain_name]->get_atom_indices(
+						std::forward<Args>(patterns)...);
+				max_result(arma::span(i, i + residue_atoms.n_rows - 1))
+					= residue_atoms + position_in_pdb;
+				i += residue_atoms.n_rows;
+				position_in_pdb += m_chain_map[chain_name]->m_natoms;
+			}
+
+			arma::Col<arma::uword> result = max_result.head(i);
+
+			return result;
+		}
 #endif
 
-private:
-	arma::Mat<T> m_xyz;
-	std::string m_filename;
-	int m_number_of_chains;
-	std::map<std::string, std::shared_ptr<Chain<T>>> m_chain_map;
-	int m_natoms;
-	std::vector<std::string> m_chain_order;
-	arma::uword m_nresidues;
-	arma::Col<T> m_radii;
-	residueVector<T> m_residues;
-	static constexpr T to_rad_constant = 180.0 / M_PI;
+	private:
+		arma::Mat<T> m_xyz;
+		std::string m_filename;
+		int m_number_of_chains;
+		std::map<std::string, std::shared_ptr<Chain<T>>> m_chain_map;
+		int m_natoms;
+		std::vector<std::string> m_chain_order;
+		arma::uword m_nresidues;
+		arma::Col<T> m_radii;
+		residueVector<T> m_residues;
+		static constexpr T to_rad_constant = 180.0 / M_PI;
 
-	void internalKS(arma::Mat<T>&);
-	arma::Mat<T> get_backbone_atoms();
-};
+		void internalKS(arma::Mat<T>&) const;
+		arma::Mat<T> get_backbone_atoms() const;
+
+		void append_new_residue(
+			const std::pair<const std::string, atomVector<T>>&,
+			residueVector<T>&, bool, bool);
+	};
 
 } // namespace prostruct
 

--- a/src/prostruct/pdb/README.md
+++ b/src/prostruct/pdb/README.md
@@ -1,0 +1,47 @@
+
+# PDB
+
+This needs to be renamed to something else, i.e. topology.
+
+## How it works:
+Currently most of the library is written in (sort of) old school C++ and written like a researcher would.
+This is fine, but becomes difficult to expand the library. All the code that supports the PDB class is in `prostruct/struct` and the parser in `struct/parsers`.
+Therefore I started working on a friendlier library API, that requires fewer interations with linear algebra code when extending the PDB (to be renamed) class:
+- the computation engine:
+  Some computations, such as dihedral angle calcuations, only require a residue and its neighbouring residues.
+  So this problem can be abstracted to a function that slides along the protein sequence and performs some calculation for each residue(s), i.e. a kernel. 
+  This is what the computation engine does: it takes a kernel and slides it along the residue vector.
+  The kernel is a C++ lambda that receives Residue object(s) as parameter(s) and returns a scalar value.
+  For example, the phi dihedral angle:
+  	The computation requires the C atom coordinates of the current residue and the coordinates for the N, CA and C in the following residue. The four atoms form two planes (i.e. C-N-CA and N-CA-C) and the angle of the intersection is calculated ([see](https://en.wikipedia.org/wiki/Dihedral_angle)).
+  	In C++:
+  	```cpp
+	auto phi_kernel = [coef](const auto& residue, const auto& residue_next) {
+		// residue and residue_next are std::shared_ptr<Residue<T>>
+		if (residue->is_c_terminus())
+			return static_cast<T>(0.0);
+		// backbone atoms are in this order: N | CA | C | O
+		auto atom_coords_this = residue->get_backbone_atoms();
+		auto atom_coords_next = residue_next->get_backbone_atoms();
+		arma::Col<T2> b1 = arma::normalise(atom_coords_this.col(2) - atom_coords_next.col(0));
+		arma::Col<T2> b2 = arma::normalise(atom_coords_next.col(0) - atom_coords_next.col(1));
+		arma::Col<T2> b3 = arma::normalise(atom_coords_next.col(1) - atom_coords_next.col(2));
+		arma::Col<T2> n1 = arma::cross(b1, b2); // plane 1
+		arma::Col<T2> n2 = arma::cross(b2, b3); // plane 2
+		// coef is just the factor needed to convert from radians to degrees
+		return std::atan2(
+				   arma::dot(arma::cross(n1, b2), n2), arma::dot(n1, n2)) * coef;
+	};
+  	```
+  	The kernel can then be passed to the engine which slides along the sequence:
+  	```cpp
+  	geometry::atom_calculation_engine<2>(m_residues, 0, phi_kernel);
+  	```
+  	The `<2>` tells engine that the window size is 2, i.e. current residue and next one is required. This is needed at compile time.
+  	The result is a matrix 1 x N_{residues}, i.e. a row vector.
+  	`geometry::atom_calculation_engine` can take an arbitrary number of kernels. The following would return a 2 x N_{residues} where the first row has the phi angles and the second psi angles.
+  	```cpp
+  	geometry::atom_calculation_engine<2>(m_residues, 0, phi_kernel, psi_kernel);`
+  	```
+  	The advantage of this approach is that the runtime is sublinear as more kernels are added because the compiler can optimise each operation on a residue, rather than two for loops which would (probably?) lead to more cache misses.
+  	It also looks very cool (in my opinion)!

--- a/src/prostruct/pdb/dihedrals.cpp
+++ b/src/prostruct/pdb/dihedrals.cpp
@@ -7,50 +7,17 @@
 namespace prostruct {
 	namespace geometry {
 		template<typename T>
-		void dihedrals(const arma::Cube<T> &atoms, arma::Col<T> &angles) {
-
-			// atom coordinates are stored in a cube (3D tensor)
-			// atoms has shape (3, 4, n_angles)
-			// where n_angles is the number of angles to calculate
-
-			for (arma::uword i = 0; i < atoms.n_slices; i++) {
-				// access cube using slice -> returns matrix
-				const arma::Mat<T> &atoms_i = atoms.slice(i);
-
-				arma::Col<T> b1 = arma::normalise(atoms_i.col(0) - atoms_i.col(1));
-				arma::Col<T> b2 = arma::normalise(atoms_i.col(1) - atoms_i.col(2));
-				arma::Col<T> b3 = arma::normalise(atoms_i.col(2) - atoms_i.col(3));
-
-				//        std::cout << "Atom: " << i << std::endl;
-				//        std::cout << "b1" << std::endl;
-				//        b1.print();
-				//        std::cout << "b2" << std::endl;
-				//        b2.print();
-				//        std::cout << "b3" << std::endl;
-				//        b3.print();
-
-				arma::Col<T> n1 = arma::cross(b1, b2);
-				arma::Col<T> n2 = arma::cross(b2, b3);
-
-				//        std::cout << "n1" << std::endl;
-				//        n1.print();
-				//
-				//        std::cout << "n2" << std::endl;
-				//        n2.print();
-
-				//        std::cout << "x" << std::endl;
-				//        n1.print();
-				//
-				//        std::cout << "y" << std::endl;
-				//        n2.print();
-
-				angles.at(i) = std::atan2(arma::dot(arma::cross(n1, b2), n2), arma::dot(n1, n2));
-
-				//        std::cout << angles.at(i) * (180.0 / M_PI) << std::endl;
-			}
+		inline T dihedrals(const arma::Col<T>& atom1, const arma::Col<T>& atom2, const arma::Col<T>& atom3, const arma::Col<T>& atom4, T coef) 
+		{
+			arma::Col<T> b1 = arma::normalise(atom1 - atom2);
+			arma::Col<T> b2 = arma::normalise(atom2 - atom3);
+			arma::Col<T> b3 = arma::normalise(atom3 - atom4);
+			arma::Col<T> n1 = arma::cross(b1, b2);	
+			arma::Col<T> n2 = arma::cross(b2, b3);
+			return std::atan2(arma::dot(arma::cross(n1, b2), n2), arma::dot(n1, n2)) * coef;
 		}
 
-		template void dihedrals(const arma::Cube<float> &, arma::Col<float> &);
-		template void dihedrals(const arma::Cube<double> &, arma::Col<double> &);
+		template float dihedrals(const arma::Col<float>&, const arma::Col<float>&, const arma::Col<float>&, const arma::Col<float>&, float);
+		template double dihedrals(const arma::Col<double>&, const arma::Col<double>&, const arma::Col<double>&, const arma::Col<double>&, double);
 	}
 }

--- a/src/prostruct/pdb/dihedrals.cpp
+++ b/src/prostruct/pdb/dihedrals.cpp
@@ -51,7 +51,6 @@ namespace prostruct {
 		}
 
 		template void dihedrals(const arma::Cube<float> &, arma::Col<float> &);
-
 		template void dihedrals(const arma::Cube<double> &, arma::Col<double> &);
 	}
 }

--- a/src/prostruct/pdb/dssp.cpp
+++ b/src/prostruct/pdb/dssp.cpp
@@ -112,8 +112,7 @@ namespace prostruct {
         template void kabsch_sander(const arma::Mat<float>&, arma::Mat<float>&);
         template void kabsch_sander(const arma::Mat<double>&, arma::Mat<double>&);
 
-        template void
-        dssp(const arma::Mat<float> &, const arma::Mat<float> &, const arma::Mat<float> &, const arma::Mat<float> &);
+        template void dssp(const arma::Mat<float> &, const arma::Mat<float> &, const arma::Mat<float> &, const arma::Mat<float> &);
 
         template void dssp(const arma::Mat<double> &, const arma::Mat<double> &, const arma::Mat<double> &,
                            const arma::Mat<double> &);

--- a/src/prostruct/pdb/geometry.h
+++ b/src/prostruct/pdb/geometry.h
@@ -61,7 +61,7 @@ namespace prostruct {
 		  *
 		  */
 		template<size_t window_size, typename T, typename ...Args>
-		arma::Mat<T> atom_calculation_engine(const prostruct::residueVector<T>& residues, Args... computations)
+		arma::Mat<T> atom_calculation_engine(const prostruct::residueVector<T>& residues, int start, Args... computations)
 		{
 			constexpr int n_computations = sizeof...(computations);
 			auto result = arma::Mat<T>(n_computations, residues.size(), arma::fill::zeros);
@@ -69,11 +69,10 @@ namespace prostruct {
 			std::tuple<Args...> comp {computations...};
 
 			int offset = std::ceil((window_size-1.0) / 2.0);
-			int remainder = window_size - offset;
 
-			for (int i = offset; i < residues.size() - remainder; ++i)
+			for (int i = start; i < residues.size() - offset; ++i)
 			{
-				execute_tuple(comp, vector_to_tuple_helper(residues, std::make_index_sequence<window_size>{}, i - offset), result.col(i - offset));
+				execute_tuple(comp, vector_to_tuple_helper(residues, std::make_index_sequence<window_size>{}, i - start), result.col(i - start));
 			}
 
 			return result;

--- a/src/prostruct/pdb/geometry.h
+++ b/src/prostruct/pdb/geometry.h
@@ -5,12 +5,10 @@
 #ifndef PROSTRUCT_GEOMETRY_H
 #define PROSTRUCT_GEOMETRY_H
 
-#include <armadillo>
-#include <array>
-#include <cmath>
 #include "prostruct/struct/residue.h"
 #include "prostruct/utils/tuple_utils.h"
-
+#include <armadillo>
+#include <array>
 
 #ifndef DNDEBUG
 #define ARMA_NO_DEBUG
@@ -19,21 +17,25 @@
 namespace prostruct {
 	namespace geometry {
 		template <typename T>
-		void dssp(const arma::Mat<T>&, const arma::Mat<T>&, const arma::Mat<T>&, const arma::Mat<T>&);
+		void dssp(const arma::Mat<T>&, const arma::Mat<T>&, const arma::Mat<T>&,
+			const arma::Mat<T>&);
 
 		template <typename T>
 		void kabsch_sander(const arma::Mat<T>&, arma::Mat<T>&);
 
 		template <typename T>
-		void predict_H_coords(arma::Mat<T>& H_coords, const arma::Mat<T>& C_coords, const arma::Mat<T>& O_coords,
+		void predict_H_coords(arma::Mat<T>& H_coords,
+			const arma::Mat<T>& C_coords, const arma::Mat<T>& O_coords,
 			const arma::Mat<T>& N_coords);
 
 		template <typename T>
-		void shrake_rupley(const arma::Mat<T>& xyz, const arma::Col<T>& radii, arma::Col<T>& asa, arma::uword n_atoms,
-		        T probe, arma::uword n_sphere_points);
+		void shrake_rupley(const arma::Mat<T>& xyz, const arma::Col<T>& radii,
+			arma::Col<T>& asa, arma::uword n_atoms, T probe,
+			arma::uword n_sphere_points);
 
 		template <typename T>
-		void get_neighbours(const arma::Mat<T>&, arma::Mat<T>&, int, const arma::Col<T>&);
+		void get_neighbours(
+			const arma::Mat<T>&, arma::Mat<T>&, int, const arma::Col<T>&);
 
 		template <typename T>
 		T rmsd(const arma::Mat<T>& xyz, const arma::Mat<T>& xyz_other);
@@ -46,37 +48,58 @@ namespace prostruct {
 		template <typename T>
 		void get_centroid(const arma::Mat<T>& xyz, arma::Col<T>& centroid);
 
-		template <typename T>
-		void recentre_molecule(arma::Mat<T>& xyz);
+		template <typename T> void recentre_molecule(arma::Mat<T>& xyz);
 
 		template <typename T>
 		void recentre_molecule(const arma::Mat<T>& xyz, arma::Mat<T>& result);
 
 		template <typename T>
-		void dihedrals(const arma::Cube<T>& atoms, arma::Col<T>& angles);
+		T dihedrals(const arma::Col<T>& atom1, const arma::Col<T>& atom2,
+			const arma::Col<T>& atom3, const arma::Col<T>& atom4, T coef);
 
-		/** 
-		  *	A near zero cost abstraction engine to execute multiple lambdas
-		  * per residue in a loop.
-		  *
-		  */
-		template<size_t window_size, typename T, typename ...Args>
-		arma::Mat<T> atom_calculation_engine(const prostruct::residueVector<T>& residues, int start, Args... computations)
+		/**
+		 *	A near zero cost abstraction engine to execute multiple lambdas
+		 * per residue in a loop.
+		 *
+		 */
+		template <size_t window_size, typename T, typename... Args>
+		arma::Mat<T> atom_calculation_engine(
+			const prostruct::residueVector<T>& residues, std::size_t start,
+			Args... computations)
 		{
 			constexpr int n_computations = sizeof...(computations);
-			auto result = arma::Mat<T>(n_computations, residues.size(), arma::fill::zeros);
+			auto result = arma::Mat<T>(
+				n_computations, residues.size(), arma::fill::zeros);
 
-			std::tuple<Args...> comp {computations...};
+			std::tuple<Args...> comp { computations... };
 
-			int offset = std::ceil((window_size-1.0) / 2.0);
-
-			for (int i = start; i < residues.size() - offset; ++i)
-			{
-				execute_tuple(comp, vector_to_tuple_helper(residues, std::make_index_sequence<window_size>{}, i - start), result.col(i - start));
+			for (std::size_t i = start; i < residues.size() - window_size + 1;
+				 ++i) {
+				execute_tuple(comp,
+					vector_to_tuple_helper(residues,
+						std::make_index_sequence<window_size> {}, i - start),
+					result.col(i - start));
 			}
 
 			return result;
 		}
+
+		/**
+		 * An untyped version of dihedrals for armadillo optimisations
+		 */
+		template <typename T1, typename T2>
+		inline T2 dihedrals_lazy(
+			T1&& atom1, T1&& atom2, T1&& atom3, T1&& atom4, T2 coef)
+		{
+			arma::Col<T2> b1 = arma::normalise(atom1 - atom2);
+			arma::Col<T2> b2 = arma::normalise(atom2 - atom3);
+			arma::Col<T2> b3 = arma::normalise(atom3 - atom4);
+			arma::Col<T2> n1 = arma::cross(b1, b2);
+			arma::Col<T2> n2 = arma::cross(b2, b3);
+			return std::atan2(
+					   arma::dot(arma::cross(n1, b2), n2), arma::dot(n1, n2))
+				* coef;
+		}
 	}
 }
-#endif //PROSTRUCT_GEOMETRY_H
+#endif // PROSTRUCT_GEOMETRY_H

--- a/src/prostruct/struct/atom.h
+++ b/src/prostruct/struct/atom.h
@@ -7,24 +7,20 @@
 
 #include <map>
 #include <memory>
+#include <regex>
 #include <string>
 #include <vector>
-#include <regex>
 
 #include "prostruct/struct/bond.h"
 #include <armadillo>
 
-template <typename T>
-using atomVector = std::vector<std::shared_ptr<Atom<T>>>;
+template <typename T> using atomVector = std::vector<std::shared_ptr<Atom<T>>>;
 
 template <typename T>
 class Atom : public std::enable_shared_from_this<Atom<T>> {
 
 public:
-	Atom(const std::string& element)
-	{
-		load_atom(element);
-	}
+	Atom(const std::string& element) { load_atom(element); }
 	Atom(const std::string&, const std::string& name)
 	{
 		load_atom(element, name);
@@ -34,10 +30,7 @@ public:
 		load_atom(element, name, x, y, z);
 	};
 
-	std::shared_ptr<Atom<T>> getAtom()
-	{
-		return this->shared_from_this();
-	};
+	std::shared_ptr<Atom<T>> getAtom() { return this->shared_from_this(); };
 
 	void addBond(std::shared_ptr<Atom<T>> atom, int bondType);
 	void addBond(std::shared_ptr<Bond<T>> bond);
@@ -68,7 +61,8 @@ private:
 	T radius;
 	void load_atom(const std::string& element);
 	void load_atom(const std::string& element, const std::string& name);
-	void load_atom(const std::string& element, const std::string& name, T x, T y, T z);
+	void load_atom(
+		const std::string& element, const std::string& name, T x, T y, T z);
 	T atomicWeight;
 	int atomicNumber;
 	std::string element;
@@ -76,4 +70,4 @@ private:
 	std::vector<std::shared_ptr<Bond<T>>> bonds;
 };
 
-#endif //PROSTRUCT_ATOM_H
+#endif // PROSTRUCT_ATOM_H

--- a/src/prostruct/struct/chain.cpp
+++ b/src/prostruct/struct/chain.cpp
@@ -10,7 +10,8 @@
 using namespace prostruct;
 
 template <typename T>
-Chain<T>::Chain(std::vector<std::shared_ptr<Residue<T>>> residues_, std::string chainName_)
+Chain<T>::Chain(
+	std::vector<std::shared_ptr<Residue<T>>> residues_, std::string chainName_)
 {
 
 	bool first = true;
@@ -39,8 +40,7 @@ Chain<T>::Chain(std::vector<std::shared_ptr<Residue<T>>> residues_, std::string 
 	m_nresidues = static_cast<int>(residues.size());
 }
 
-template <typename T>
-chainAtomVector<T> Chain<T>::getBackboneAtoms()
+template <typename T> chainAtomVector<T> Chain<T>::getBackboneAtoms()
 {
 	std::vector<std::vector<std::shared_ptr<Atom<T>>>> backboneAtoms;
 	backboneAtoms.reserve(m_nresidues);

--- a/src/prostruct/struct/chain.h
+++ b/src/prostruct/struct/chain.h
@@ -20,7 +20,7 @@ namespace prostruct {
 		Chain(std::vector<std::shared_ptr<Residue<T>>>, std::string);
 		int n_residues() { return m_nresidues; };
 		int n_atoms() { return m_natoms; };
-		std::vector<std::shared_ptr<Residue<T>>> getResidues() { return residues; }
+		residueVector<T> getResidues() { return residues; }
 		chainAtomVector<T> getBackboneAtoms();
 
 	private:

--- a/src/prostruct/struct/chain.h
+++ b/src/prostruct/struct/chain.h
@@ -7,14 +7,11 @@
 
 #include "prostruct/struct/residue.h"
 
-template <typename T>
-using chainAtomVector = std::vector<atomVector<T>>;
+template <typename T> using chainAtomVector = std::vector<atomVector<T>>;
 
 namespace prostruct {
-	template <typename T>
-	class Chain {
-		template <typename T1>
-	    friend class PDB;
+	template <typename T> class Chain {
+		template <typename T1> friend class PDB;
 
 	public:
 		Chain(std::vector<std::shared_ptr<Residue<T>>>, std::string);
@@ -24,30 +21,34 @@ namespace prostruct {
 		chainAtomVector<T> getBackboneAtoms();
 
 	private:
-        std::string chainName;
+		std::string chainName;
 		std::vector<std::shared_ptr<Residue<T>>> residues;
 		int m_nresidues;
 		int m_natoms;
+
 	protected:
 		template <typename... Args>
 		arma::Col<arma::uword> get_atom_indices(Args... patterns)
 		{
-			arma::Col<arma::uword> max_result(m_nresidues*m_natoms);
+			arma::Col<arma::uword> max_result(m_nresidues * m_natoms);
 			arma::uword i = 0;
 			arma::uword position_in_chain = 0;
 
-		    for(const auto& residue: residues) {
-				arma::Col<arma::uword> residue_atoms = residue->get_atom_indices(std::forward<Args>(patterns)...);
-		        max_result.subvec(arma::span(i, i+residue_atoms.n_rows-1)) = residue_atoms + position_in_chain;
-		    	i+=residue_atoms.n_rows;
-		        position_in_chain += residue->n_atoms();
-		    }
+			for (const auto& residue : residues) {
+				arma::Col<arma::uword> residue_atoms
+					= residue->get_atom_indices(
+						std::forward<Args>(patterns)...);
+				max_result.subvec(arma::span(i, i + residue_atoms.n_rows - 1))
+					= residue_atoms + position_in_chain;
+				i += residue_atoms.n_rows;
+				position_in_chain += residue->n_atoms();
+			}
 
-		    arma::Col<arma::uword> result = max_result.head(i);
+			arma::Col<arma::uword> result = max_result.head(i);
 
 			return result;
 		}
 	};
 }
 
-#endif //PROSTRUCT_CHAIN_H
+#endif // PROSTRUCT_CHAIN_H

--- a/src/prostruct/struct/residue.cpp
+++ b/src/prostruct/struct/residue.cpp
@@ -485,19 +485,17 @@ const static stringIndexMap aminoAcidIndex {
 	{ "VAL", 19 }
 };
 
+/**
+ *  The Residue class represent one of the twenty standard amino acids.
+ *  A Residue is made of Atom objects which are connected via Bond objects.
+ *
+ *  @param[in] atoms_ Vector of Atom objects
+ *  @param[in] aminoAcidName_ name of amino acid
+ *  @param[in] residueName_ name of residue
+ */
 template <typename T>
-Residue<T>::Residue(atomVector<T> atoms_, const std::string& aminoAcidName_, const std::string& residueName_)
+Residue<T>::Residue(atomVector<T> atoms_, const std::string& aminoAcidName_, const std::string& residueName_, bool n_terminus, bool c_terminus)
 {
-
-	/**
-     *  The Residue class represent one of the twenty standard amino acids.
-     *  A Residue is made of Atom objects which are connected via Bond objects.
-     *
-     *  @param[in] atoms_ Vector of Atom objects
-     *  @param[in] aminoAcidName_ name of amino acid
-     *  @param[in] residueName_ name of residue
-     */
-
 	backbone = std::vector<int>(4);
 
 	if (aminoAcidIndex.find(aminoAcidName_) != aminoAcidIndex.end()) {
@@ -547,6 +545,9 @@ Residue<T>::Residue(atomVector<T> atoms_, const std::string& aminoAcidName_, con
 	residueName = residueName_;
 
 	createBonds();
+
+	m_n_terminus = n_terminus;
+	m_c_terminus = c_terminus;
 }
 
 template <typename T>

--- a/src/prostruct/struct/residue.h
+++ b/src/prostruct/struct/residue.h
@@ -61,6 +61,11 @@ namespace prostruct {
 			return backboneAtoms;
 		}
 
+		arma::Mat<T> get_backbone_atoms()
+		{
+			return xyz(arma::span::all, arma::span(0, 3));
+		}
+
 		atomVector<T> getSidechain()
 		{
 			std::vector<std::shared_ptr<Atom<T>>> sidechainAtoms;
@@ -132,7 +137,7 @@ namespace prostruct {
 		std::map<std::string, int> atomMap; /**< Map atom name to internal index */
 	};
 
-	template <typename T>
+		template <typename T>
 	using residueVector = std::vector<std::shared_ptr<Residue<T>>>;
 }
 

--- a/src/prostruct/struct/residue.h
+++ b/src/prostruct/struct/residue.h
@@ -14,10 +14,7 @@ namespace prostruct {
 	using aminoAcidAtomMap = std::vector<std::map<std::string, std::string>>;
 	using stringIndexMap = std::map<std::string, int>;
 
-	enum class aaLocation {
-		Backbone,
-		Sidechain
-	};
+	enum class aaLocation { Backbone, Sidechain };
 
 	enum class AminoAcid {
 		ARG,
@@ -42,15 +39,14 @@ namespace prostruct {
 		VAL
 	};
 
-	template <typename T>
-	class Residue {
-		template <typename T1>
-		friend class Chain;
+	template <typename T> class Residue {
+		template <typename T1> friend class Chain;
 
 	public:
 		// takes an arbitrary number of atoms and tries to form a residue
 		//    Residue(std::unique_ptr<Atom> atoms...);
-		Residue(atomVector<T>, const std::string&, const std::string&);
+		Residue(atomVector<T>, const std::string&, const std::string&,
+			bool = false, bool = false);
 
 		atomVector<T> getBackbone()
 		{
@@ -75,7 +71,10 @@ namespace prostruct {
 			return sidechainAtoms;
 		}
 
-		std::shared_ptr<Atom<T>> operator[](const int index) { return atoms[index]; }
+		std::shared_ptr<Atom<T>> operator[](const int index)
+		{
+			return atoms[index];
+		}
 
 		arma::Mat<T> getXYZ() { return xyz; }
 
@@ -101,19 +100,21 @@ namespace prostruct {
 
 		arma::Col<T> getRadii() { return radii; }
 
+		bool is_n_terminus() { return m_n_terminus; }
+
+		bool is_c_terminus() { return m_c_terminus; }
+
 	protected:
-		template <typename...Args>
+		template <typename... Args>
 		arma::Col<arma::uword> get_atom_indices(Args... patterns)
 		{
 			arma::Col<arma::uword> max_result(atoms.size());
-			std::vector<std::string> vec = {patterns...};
+			std::vector<std::string> vec = { patterns... };
 
 			arma::uword result_idx = 0;
-			for (const auto& pattern: vec)
-			{
+			for (const auto& pattern : vec) {
 				arma::uword i = 0;
-				for (const auto& atom: atoms)
-				{
+				for (const auto& atom : atoms) {
 					if (atom->getName() == pattern) {
 						max_result(result_idx) = i;
 						result_idx++;
@@ -128,17 +129,23 @@ namespace prostruct {
 	private:
 		arma::Mat<T> xyz;
 		arma::Col<T> radii;
-		std::vector<int> backbone; /**< A vector with the index number of the backbone atoms */
-		std::vector<int> sidechain; /**< A vector with the index number of the sidechain atoms */
+		bool m_n_terminus;
+		bool m_c_terminus;
+		std::vector<int> backbone; /**< A vector with the index number of the
+									  backbone atoms */
+		std::vector<int> sidechain; /**< A vector with the index number of the
+									   sidechain atoms */
 		std::string aminoAcidName; /**< Name of the amino acid, e.g. ALA */
 		enum AminoAcid aminoAcid; /**< Amino acid enum, e.g. ALA */
 		std::string residueName; /**< Name of the residue, e.g. ALA1 */
-		atomVector<T> atoms; /**< A vector with the pointers to the Atom objects */
-		std::map<std::string, int> atomMap; /**< Map atom name to internal index */
+		atomVector<T>
+			atoms; /**< A vector with the pointers to the Atom objects */
+		std::map<std::string, int>
+			atomMap; /**< Map atom name to internal index */
 	};
 
-		template <typename T>
+	template <typename T>
 	using residueVector = std::vector<std::shared_ptr<Residue<T>>>;
 }
 
-#endif //PROSTRUCT_RESIDUE_H
+#endif // PROSTRUCT_RESIDUE_H

--- a/src/prostruct/utils/tuple_utils.h
+++ b/src/prostruct/utils/tuple_utils.h
@@ -44,7 +44,6 @@ namespace prostruct {
 		const std::tuple<LambdaArgs...>& lambda_args,
 		ResultType&& result)
 	{
-		//static_assert(result.size() == sizeof...(Args), "Expected result array to be the same size as lambda tuple");
 		return execute_tuple_helper(lambda_tuple, lambda_args, std::index_sequence_for<Args...>{}, std::forward<ResultType>(result));
 	}
 

--- a/src/prostruct/utils/tuple_utils.h
+++ b/src/prostruct/utils/tuple_utils.h
@@ -1,0 +1,55 @@
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <armadillo>
+
+namespace prostruct {
+	// taken from https://stackoverflow.com/a/12650100
+	template<size_t N>
+	struct Apply {
+	    template<typename F, typename T, typename... A>
+	    static inline auto apply(F && f, T && t, A &&... a) {
+	        return Apply<N-1>::apply(::std::forward<F>(f), ::std::forward<T>(t),
+	            ::std::get<N-1>(::std::forward<T>(t)), ::std::forward<A>(a)...
+	        );
+	    }
+	};
+
+	template<>
+	struct Apply<0> {
+	    template<typename F, typename T, typename... A>
+	    static inline auto apply(F && f, T &&, A &&... a) {
+	        return ::std::forward<F>(f)(::std::forward<A>(a)...);
+	    }
+	};
+
+	template<typename F, typename T, typename ResultType>
+	void apply(F && f, T && t, ResultType& result) {
+	    result = Apply< ::std::tuple_size< ::std::decay_t<T>
+	      >::value>::apply(::std::forward<F>(f), ::std::forward<T>(t));
+	}
+
+	// adapted from https://en.cppreference.com/w/cpp/utility/integer_sequence
+	template <typename LambdaTuple, typename ...LambdaArgs, std::size_t... Idx, typename ResultType>
+	void execute_tuple_helper(const LambdaTuple& lambda_tuple, 
+		const std::tuple<LambdaArgs...>& lambda_args, 
+		std::index_sequence<Idx...>,
+		ResultType&& result)
+	{
+		return (apply(std::get<Idx>(lambda_tuple), lambda_args, result[Idx]), ...);
+	}
+
+	template <typename ...Args, typename ...LambdaArgs, typename ResultType>
+	void execute_tuple(const std::tuple<Args...>& lambda_tuple, 
+		const std::tuple<LambdaArgs...>& lambda_args,
+		ResultType&& result)
+	{
+		//static_assert(result.size() == sizeof...(Args), "Expected result array to be the same size as lambda tuple");
+		return execute_tuple_helper(lambda_tuple, lambda_args, std::index_sequence_for<Args...>{}, std::forward<ResultType>(result));
+	}
+
+	template <typename T, std::size_t... Idx>
+	auto vector_to_tuple_helper(const std::vector<T>& vec, std::index_sequence<Idx...>, size_t offset) {
+ 		return std::make_tuple(vec[Idx + offset]...);
+	}
+}

--- a/tests/pdb/PDBTest.cpp
+++ b/tests/pdb/PDBTest.cpp
@@ -95,3 +95,16 @@ TYPED_TEST(PDBTest, Kabsch_RMSD)
 
 	EXPECT_NEAR(rmsd, 0.0, get_epsilon<TypeParam>());
 }
+
+TYPED_TEST(PDBTest, phi_angles)
+{
+	auto pdb = PDB<TypeParam>("test.pdb");
+
+	auto phi_degree = pdb.calculate_phi();
+
+	EXPECT_NEAR(phi_degree(10), -76.065502471, get_epsilon<TypeParam>());
+
+	auto phi_rad = pdb.calculate_phi(true);
+
+	EXPECT_NEAR(phi_rad(10), -1.3275937, get_epsilon<TypeParam>());
+}

--- a/tests/pdb/PDBTest.cpp
+++ b/tests/pdb/PDBTest.cpp
@@ -108,3 +108,16 @@ TYPED_TEST(PDBTest, phi_angles)
 
 	EXPECT_NEAR(phi_rad(10), -1.3275937, get_epsilon<TypeParam>());
 }
+
+TYPED_TEST(PDBTest, psi_angles)
+{
+	auto pdb = PDB<TypeParam>("test.pdb");
+
+	auto psi_degree = pdb.calculate_psi();
+
+	EXPECT_NEAR(psi_degree(10), 94.52472, get_epsilon<TypeParam>());
+
+	auto psi_rad = pdb.calculate_psi(true);
+
+	EXPECT_NEAR(psi_rad(10), 1.6497685, get_epsilon<TypeParam>());
+}

--- a/tests/struct/residueTest.cpp
+++ b/tests/struct/residueTest.cpp
@@ -12,12 +12,12 @@ template <typename T>
 class ResidueTestClass: public Residue<T>
 {
 public:
-    template <class... Args>
-    ResidueTestClass(Args... m): Residue<T>(m...) {};
+	template <class... Args>
+	ResidueTestClass(Args... m): Residue<T>(m...) {};
 
-    auto get_atom_indices(const std::string& name) {
-        return Residue<T>::get_atom_indices(name);
-    }
+	auto get_atom_indices(const std::string& name) {
+		return Residue<T>::get_atom_indices(name);
+	}
 };
 
 TEST(ResidueTest, Alanine) {
@@ -43,8 +43,8 @@ TEST(ResidueTest, Alanine) {
 
 	ASSERT_EQ(ala.get_atom_indices("N")(0), 0);
 	ASSERT_EQ(ala.get_atom_indices("N").size(), 1);
-    ASSERT_EQ(ala.get_atom_indices("C")(0), 2);
-    ASSERT_EQ(ala.get_atom_indices("C").size(), 1);
+	ASSERT_EQ(ala.get_atom_indices("C")(0), 2);
+	ASSERT_EQ(ala.get_atom_indices("C").size(), 1);
 }
 
 TEST(ResidueTest, Argenine)


### PR DESCRIPTION
possible solution for #2:
- Lambdas representing a kernel are perfectly forwarded to be used in computations alongs the protein sequence
- The underlying "engine" is as close to zero abstraction as I could get for now
- The window size has to be known at compile time, but could potentially move to runtime if function were to be exposed to swig